### PR TITLE
Trying to translate access date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,10 @@
 *.blg
 *.pag
 *.toc
+*.xdv
 *.pdf
+*.dvi
+*.fls
 /.aspell*
 /*.synctex.gz
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ $(NAME).pdf: $(FILES_TEX)
 	$(XELATEX) $<
 
 clean:
-	$(RM) *.bak *.out *.toc *.bcf *.bbl *.blg *.aux *.nav *.vrb *.snm *.log $(NAME).run.xml *.synctex.gz
+	$(RM) *.bak *.out *.toc *.bcf *.bbl *.blg *.aux *.nav *.vrb *.snm *.log *.xdv *.fls *.dvi $(NAME).run.xml *.synctex.gz
 
 aspell:
 	aspell --mode=tex -l ru --home-dir=. --personal=personal_dict.txt  -c $(FILE)

--- a/ugost2008ls.bst
+++ b/ugost2008ls.bst
@@ -574,20 +574,24 @@ FUNCTION {bbl.ppage}  %   { "\bblP." }
    if$}
 if$}
 
+% Kakadu: let's write access date everywhere, because most of student's
+% graduations works are in Russian
 FUNCTION {bbl.urldate}
-{ curlanguage "english" =
-   {"online; accessed"}
-   { curlanguage "ukrainian" =
-      { "{дата звернення}" }
-      { curlanguage "russian" =
-         { "{дата обращения}" }
-         { curlanguage "german" =
-            { "{online; abgerufen}" }
-            { "language is not defined: " language "urldate" * * warning$ "online; accessed" }
-         if$}
-      if$}
-   if$}
-if$}
+{ "{дата обращения}" }
+%FUNCTION {bbl.urldate}
+%{ curlanguage "english" =
+%   {"online; accessed"}
+%   { curlanguage "ukrainian" =
+%      { "{дата звернення}" }
+%      { curlanguage "russian" =
+%         { "{дата обращения}" }
+%         { curlanguage "german" =
+%            { "{online; abgerufen}" }
+%            { "language is not defined: " language "urldate" * * warning$ "online; accessed" }
+%         if$}
+%      if$}
+%   if$}
+%if$}
 
 FUNCTION {bbl.techreport} % rename to bbl.techreport
 { curlanguage "english" =

--- a/vkr.bib
+++ b/vkr.bib
@@ -12,6 +12,7 @@
  title = {How to Give a Great Research Talk},
  url = {https://www.microsoft.com/en-us/research/academic-program/give-great-research-talk/},
  urldate = {2021-11-21},
+ language={russian},
 }
 
 @incollection{SPJGreatPaper,
@@ -19,6 +20,7 @@
  title = {How to Write a Great Research Paper},
  url = {https://www.microsoft.com/en-us/research/academic-program/write-great-research-paper/},
  urldate = {2021-11-21},
+ language={russian},
 }
 
 @incollection{DreyerYoutube2020,
@@ -27,6 +29,7 @@
  url = {https://www.youtube.com/watch?v=XpgJ31GKPWI},
  urldate = {2021-11-21},
  year = {2020},
+ language={russian},
 }
 
 @incollection{JhalaYoutube2020,
@@ -35,6 +38,7 @@
  url = {https://www.youtube.com/watch?v=aFT79TmffPk},
  urldate = {2021-11-21},
  year = {2020},
+ language={russian},
 }
 
 @inproceedings{HC,
@@ -53,6 +57,7 @@
  publisher = {ACM},
  address = {New York, NY, USA},
  keywords = {data structures, hash-consing, sharing},
+ language={russian},
 } 
 @Inbook{CalculatingFP,
 author="Gibbons, Jeremy",
@@ -68,7 +73,8 @@ pages="151--203",
 abstract="Functional programs are merely equations; they may be manipulated by straightforward equational reasoning. In particular, one can use this style of reasoning to calculate programs, in the same way that one calculates numeric values in arithmetic. Many useful theorems for such reasoning derive from an algebraic view of programs, built around datatypes and their operations. Traditional algebraic methods concentrate on initial algebras, constructors, and values; dual co-algebraic methods concentrate on final co-algebras, destructors, and processes. Both methods are elegant and powerful; they deserve to be combined.",
 isbn="978-3-540-47797-6",
 doi="10.1007/3-540-47797-7_5",
-url="https://doi.org/10.1007/3-540-47797-7_5"
+url="https://doi.org/10.1007/3-540-47797-7_5",
+ language={russian},
 }
 
 @book{MMM,

--- a/vkr.bib
+++ b/vkr.bib
@@ -12,7 +12,6 @@
  title = {How to Give a Great Research Talk},
  url = {https://www.microsoft.com/en-us/research/academic-program/give-great-research-talk/},
  urldate = {2021-11-21},
- language={russian},
 }
 
 @incollection{SPJGreatPaper,
@@ -20,7 +19,6 @@
  title = {How to Write a Great Research Paper},
  url = {https://www.microsoft.com/en-us/research/academic-program/write-great-research-paper/},
  urldate = {2021-11-21},
- language={russian},
 }
 
 @incollection{DreyerYoutube2020,
@@ -29,7 +27,6 @@
  url = {https://www.youtube.com/watch?v=XpgJ31GKPWI},
  urldate = {2021-11-21},
  year = {2020},
- language={russian},
 }
 
 @incollection{JhalaYoutube2020,
@@ -38,7 +35,6 @@
  url = {https://www.youtube.com/watch?v=aFT79TmffPk},
  urldate = {2021-11-21},
  year = {2020},
- language={russian},
 }
 
 @inproceedings{HC,
@@ -57,8 +53,8 @@
  publisher = {ACM},
  address = {New York, NY, USA},
  keywords = {data structures, hash-consing, sharing},
- language={russian},
-} 
+}
+
 @Inbook{CalculatingFP,
 author="Gibbons, Jeremy",
 editor="Backhouse, Roland
@@ -74,7 +70,6 @@ abstract="Functional programs are merely equations; they may be manipulated by s
 isbn="978-3-540-47797-6",
 doi="10.1007/3-540-47797-7_5",
 url="https://doi.org/10.1007/3-540-47797-7_5",
- language={russian},
 }
 
 @book{MMM,


### PR DESCRIPTION
I found a solution that specifies a language for a citation.
If set to 'russian' it automatically translates 'access date'
which is good. But a side effect is that it changes order in
First-Last-Middle name. I don't know is it OK to do this for
English papers. Because of that I propose it as a pull request.

Maybe, in general, it would be better to adopt bibliography from
Ph.D. template:
https://github.com/AndreyAkinshin/Russian-Phd-LaTeX-Dissertation-Template/blob/master/biblio/biblatex.tex

