### PR TITLE
fix: re-build pdf on updating non-main TeX files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ ENGINE ?= xelatex # Only `xelatex` or `lualatex` are allowed here
 
 all: $(VKR).pdf $(TALK).pdf
 
-%.pdf: %.tex
-	latexmk -$(ENGINE) -synctex=1 -interaction=nonstopmode -file-line-error -shell-escape $^
+%.pdf: %.tex %.bib *.tex
+	latexmk -$(ENGINE) -synctex=1 -interaction=nonstopmode -file-line-error -shell-escape $<
 
 clean:
 	latexmk -c $(VKR).tex $(TALK).tex


### PR DESCRIPTION
This patch makes building command detect updates in non-main `.tex` and corresponding `.bib` files and re-build the resulting pdf file.

This is achieved by adding `*.tex` and corresponding `.bib` files as prerequisites for the output pdf file in the Makefile.

Previous behavior:
```
$ vi 010_intro.tex

...

$ make

make: Nothing to be done for 'all'.
```

New behavior:
```
$ vi 010_intro.tex

...

$ make

Start building...
```