### PR TITLE
fix: repair presentation build missing bib file

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,5 +1,5 @@
 name: Build LaTeX document
-on: [push]
+on: [push, pull_request]
 jobs:
   build_latex:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ENGINE ?= xelatex # Only `xelatex` or `lualatex` are allowed here
 
 all: $(VKR).pdf $(TALK).pdf
 
-%.pdf: %.tex %.bib *.tex
+%.pdf: %.tex *.bib *.tex
 	latexmk -$(ENGINE) -synctex=1 -interaction=nonstopmode -file-line-error -shell-escape $<
 
 clean:


### PR DESCRIPTION
This is a patchset for fixing presentation build problems that occur after closing #30.

The first patch fixes building presentation template after 2ee060a2
('fix: re-build pdf on updating non-main TeX files').

The problem appeared due to `%.pdf` `%.bib` prerequisite. It has been
missing for `talk.pdf`. Now `%.pdf` files simply use `*.bib` files as
prerequisites.

The second patch makes CI run LaTeX build not only on pushes but on pull
requests too to avoid such problems.
