### PR TITLE
Delete option kpsewhich of package minted

### DIFF
--- a/matmex-diploma-custom.cls
+++ b/matmex-diploma-custom.cls
@@ -136,7 +136,7 @@
 }
 
 % Требует Python с пакетом pygmentize, зато позволяет верстать очень годные листинги с синтаксической подсветкой
-\usepackage[kpsewhich,newfloat]{minted}
+\usepackage[newfloat]{minted}
 
 % Запретим minted подсвечивать по его мнению лексические ошибки
 \AtBeginEnvironment{minted}{\dontdofcolorbox}


### PR DESCRIPTION
Опция kpsewhich устарела -- при сборке с помощью TeX Live 2025 возникает ошибка "Package minted Error: Package option "kpsewhich" is no longer needed with minted v3+."